### PR TITLE
Fix admin - Changes to ErrorStateMatcher

### DIFF
--- a/src/app/admin/approvers/approvers.component.html
+++ b/src/app/admin/approvers/approvers.component.html
@@ -28,17 +28,23 @@
                             <mat-form-field appearance="outline" class="mat-input-width">
                                 <mat-label>Name</mat-label>
                                 <input matInput formControlName="name" 
-                                required>
+                                [errorStateMatcher]="errorStateMatcher"
+                                required />
+                                <mat-error>Name must be letters only</mat-error>
                             </mat-form-field>
                             <mat-form-field appearance="outline" class="mat-input-width">
                                 <mat-label>Phone</mat-label>
                                 <input matInput formControlName="phone" 
-                                required>
+                                [errorStateMatcher]="errorStateMatcher"
+                                required />
+                                <mat-error>Phone number must be 10 digit</mat-error>
                             </mat-form-field>
                             <mat-form-field appearance="outline" class="mat-input-width">
                                 <mat-label>Email</mat-label>
-                                <input matInput formControlName="email"  
-                                required>
+                                <input matInput formControlName="email"
+                                [errorStateMatcher]="errorStateMatcher"  
+                                required />
+                                <mat-error>Email is required with correct email format</mat-error>
                             </mat-form-field>
                             <div class="button-container">
                                 <button mat-raised-button color="primary" (click)="add()" [disabled]="!newApprover.valid">Add</button>
@@ -92,15 +98,24 @@
                                     <mat-label>Name</mat-label>
                                     <input matInput  appearance="outline" 
                                     formControlName="name"
-                                    >
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher"
+                                    />
+                                    <mat-error>Name must be letters only</mat-error>
                                   </mat-form-field>
                                   <mat-form-field appearance="outline" class="mat-input-width">
                                     <mat-label>Phone</mat-label>
-                                    <input matInput  formControlName="phone">
+                                    <input matInput  formControlName="phone" 
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher"/>
+                                    <mat-error>Phone number must be 10 digit</mat-error>
                                   </mat-form-field>
                                   <mat-form-field  appearance="outline" class="mat-input-width">
                                     <mat-label>Email</mat-label>
-                                    <input matInput formControlName="email">
+                                    <input matInput formControlName="email"
+                                    required 
+                                    [errorStateMatcher]="errorStateMatcher"/>
+                                    <mat-error>Email is required with correct email format</mat-error>
                                   </mat-form-field>
                                   <div class="button-container">
                                     <button mat-raised-button color="primary" (click)="edit()" >Update</button>
@@ -130,15 +145,24 @@
                                     <mat-label>Name</mat-label>
                                     <input matInput  appearance="outline" 
                                     formControlName="name"
-                                    >
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher"
+                                    />
+                                    <mat-error>Name must be letters only</mat-error>
                                   </mat-form-field>
                                   <mat-form-field appearance="outline" class="mat-input-width">
                                     <mat-label>Phone</mat-label>
-                                    <input matInput  formControlName="phone">
+                                    <input matInput  formControlName="phone"
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher" />
+                                    <mat-error>Phone number must be 10 digit</mat-error>
                                   </mat-form-field>
                                   <mat-form-field  appearance="outline" class="mat-input-width">
                                     <mat-label>Email</mat-label>
-                                    <input matInput formControlName="email">
+                                    <input matInput formControlName="email"
+                                    required 
+                                    [errorStateMatcher]="errorStateMatcher" />
+                                    <mat-error>Email is required with correct email format</mat-error>
                                   </mat-form-field>
                                   <div class="button-container">
                                     <button mat-raised-button color="primary" (click)="edit()">Update</button>
@@ -169,15 +193,24 @@
                                     <mat-label>Name</mat-label>
                                     <input matInput  appearance="outline" 
                                     formControlName="name"
-                                    >
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher"
+                                    />
+                                    <mat-error>Name must be letters only</mat-error>
                                   </mat-form-field>
                                   <mat-form-field appearance="outline" class="mat-input-width">
                                     <mat-label>Phone</mat-label>
-                                    <input matInput  formControlName="phone">
+                                    <input matInput  formControlName="phone"
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher" />
+                                    <mat-error>Phone number must be 10 digit</mat-error>
                                   </mat-form-field>
                                   <mat-form-field  appearance="outline" class="mat-input-width">
                                     <mat-label>Email</mat-label>
-                                    <input matInput formControlName="email">
+                                    <input matInput formControlName="email" 
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher" />
+                                    <mat-error>Email is required with correct email format</mat-error>
                                   </mat-form-field>
                                   <div class="button-container">
                                     <button mat-raised-button color="primary" (click)="edit()" >Update</button>
@@ -207,15 +240,24 @@
                                     <mat-label>Name</mat-label>
                                     <input matInput  appearance="outline" 
                                     formControlName="name"
-                                    >
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher"
+                                    />
+                                    <mat-error>Name must be letters only</mat-error>
                                   </mat-form-field>
                                   <mat-form-field appearance="outline" class="mat-input-width">
                                     <mat-label>Phone</mat-label>
-                                    <input matInput  formControlName="phone">
+                                    <input matInput  formControlName="phone"
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher" />
+                                    <mat-error>Phone number must be 10 digit</mat-error>
                                   </mat-form-field>
                                   <mat-form-field  appearance="outline" class="mat-input-width">
                                     <mat-label>Email</mat-label>
-                                    <input matInput formControlName="email">
+                                    <input matInput formControlName="email"
+                                    required
+                                    [errorStateMatcher]="errorStateMatcher" />
+                                    <mat-error>Email is required with correct email format</mat-error>
                                   </mat-form-field>
                                   <div class="button-container">
                                     <button mat-raised-button color="primary" (click)="edit()" >Update</button>

--- a/src/app/admin/approvers/approvers.component.ts
+++ b/src/app/admin/approvers/approvers.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormControl, FormGroup, FormGroupDirective, NgForm, Validators } from '@angular/forms';
+import { ErrorStateMatcher } from '@angular/material/core';
 
 import { Router } from '@angular/router';
 import { AdminService } from 'src/app/core/services/admin.service';
@@ -10,6 +11,7 @@ import { AdminService } from 'src/app/core/services/admin.service';
   styleUrls: ['./approvers.component.css'],
 })
 export class ApproversComponent implements OnInit {
+  errorStateMatcher = new InstantErrorStateMatcher();
   //four arrays
   divChief: Array<any> = [];
   deptInfo: Array<any> = [];
@@ -263,5 +265,16 @@ export class ApproversComponent implements OnInit {
           this.sucess = true;
         });
     }
+  }
+}
+
+// changes the ErrorStateMatcher to include dirty
+// removes the error message and red boxes after clicking next
+class InstantErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(
+    control: FormControl | null,
+    form: FormGroupDirective | NgForm | null
+  ): boolean {
+    return control && control.invalid && (control.dirty || control.touched);
   }
 }

--- a/src/app/admin/review-confirmation-page/review-confirmation-page.component.html
+++ b/src/app/admin/review-confirmation-page/review-confirmation-page.component.html
@@ -1,0 +1,15 @@
+<div class="container mb-4 mt-4">
+    <div class="alert alert-success" role="alert">
+      <h4 class="alert-heading">Thanks! Submission Received</h4>
+      <p>Service request has been submitted to Adobe Sign for signing for request number provided below.
+      </p>
+      <hr />
+      <p class="mb-0">Request number:
+          <span id="request-number" class="font-weight-bold">
+              {{requestNumber}}
+          </span>
+      </p>
+    </div>
+    <hr />
+    <p><a routerLink="/admin/service-requests">Redirect to homepage</a></p>
+  </div>

--- a/src/app/admin/review-confirmation-page/review-confirmation-page.component.spec.ts
+++ b/src/app/admin/review-confirmation-page/review-confirmation-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReviewConfirmationPageComponent } from './review-confirmation-page.component';
+
+describe('ReviewConfirmationPageComponent', () => {
+  let component: ReviewConfirmationPageComponent;
+  let fixture: ComponentFixture<ReviewConfirmationPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ReviewConfirmationPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ReviewConfirmationPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/review-confirmation-page/review-confirmation-page.component.ts
+++ b/src/app/admin/review-confirmation-page/review-confirmation-page.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { ConfirmationPageService } from 'src/app/core/services/confirmation-page.service';
+
+@Component({
+  selector: 'app-review-confirmation-page',
+  templateUrl: './review-confirmation-page.component.html',
+  styleUrls: ['./review-confirmation-page.component.css'],
+})
+export class ReviewConfirmationPageComponent implements OnInit {
+  requestNumber: number;
+
+  constructor(
+    private confirmationPageService: ConfirmationPageService,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.requestNumber = this.confirmationPageService.requestNumber;
+    // TODO: Make a guard for this. This is a temporary fix.
+    if (this.requestNumber === undefined) {
+      this.router.navigate(['admin/service-requests']);
+    }
+  }
+}

--- a/src/app/admin/review-employee/review-employee.component.html
+++ b/src/app/admin/review-employee/review-employee.component.html
@@ -4,6 +4,7 @@
   [formGroup]="approval"
   [@myAnimation]
   class="container"
+  [style.display]="isLoading ? 'none' : 'block'"
 >
   <!-- Personal Information Step -->
   <mat-horizontal-stepper #stepper>
@@ -677,3 +678,8 @@
     </mat-step>
   </mat-horizontal-stepper>
 </form>
+
+<!-- Loading page -->
+<ng-container *ngIf="isLoading">
+  <app-loading-page></app-loading-page>
+</ng-container>

--- a/src/app/admin/review-employee/review-employee.component.ts
+++ b/src/app/admin/review-employee/review-employee.component.ts
@@ -11,8 +11,9 @@ import { ErrorStateMatcher } from '@angular/material/core';
 import { AdminService } from 'src/app/core/services/admin.service';
 import { ApiHttpService } from 'src/app/core/services/api-http.service';
 import { FormDataService } from 'src/app/core/services/form-data.service';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { animate, style, transition, trigger } from '@angular/animations';
+import { ConfirmationPageService } from 'src/app/core/services/confirmation-page.service';
 
 @Component({
   selector: 'app-review-employee',
@@ -63,13 +64,18 @@ export class ReviewEmployeeComponent implements OnInit {
   //selected value
   selectedValue: any;
 
+  //for loading after form is submitted
+  isLoading = false;
+
   //approval FormGroup-manager, divisionChief, etc
   approval: FormGroup;
   constructor(
     private formDataService: FormDataService,
     private adminService: AdminService,
     private apiHttpService: ApiHttpService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private confirmationPageService: ConfirmationPageService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -345,15 +351,20 @@ export class ReviewEmployeeComponent implements OnInit {
 
   //not working yet-set complete to true
   startAdobeProcess = (): void => {
+    this.isLoading = true;
     this.adminService
       .submitForm(
         this.formDataService.formData.requestNumber,
         this.approval.value,
         true
       )
-      .subscribe((res) => {
-        console.log(res);
-        this.formDataService.formData = res;
+      .subscribe({
+        next: (response) => {
+          this.formDataService.formData = response;
+          this.confirmationPageService.requestNumber = response.requestNumber;
+          this.router.navigate(['admin/review-confirmation-page']);
+          console.log(response);
+        }
       });
   };
 
@@ -389,7 +400,7 @@ export class ReviewEmployeeComponent implements OnInit {
 
 // changes the ErrorStateMatcher to include dirty
 // removes the error message and red boxes after clicking next
-export class InstantErrorStateMatcher implements ErrorStateMatcher {
+class InstantErrorStateMatcher implements ErrorStateMatcher {
   isErrorState(
     control: FormControl | null,
     form: FormGroupDirective | NgForm | null

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -13,6 +13,7 @@ import { ReviewRequestComponent } from './admin/review-contractor/review-contrac
 import { ReviewEmployeeComponent } from './admin/review-employee/review-employee.component';
 import { ConfirmationPageComponent } from './confirmation-page/confirmation-page.component';
 import { ApproversComponent } from './admin/approvers/approvers.component';
+import { ReviewConfirmationPageComponent } from './admin/review-confirmation-page/review-confirmation-page.component';
 
 const routes: Routes = [
   {
@@ -38,6 +39,11 @@ const routes: Routes = [
       {
         path: 'service-requests',
         component: ServiceRequestsComponent,
+        canActivate: [AuthGuard],
+      },
+      {
+        path: 'review-confirmation-page',
+        component: ReviewConfirmationPageComponent,
         canActivate: [AuthGuard],
       },
       {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -47,6 +47,7 @@ import { SubmissionConfirmationPageComponent } from './form/shared/submission-co
 import { HomepageComponent } from './homepage/homepage.component';
 import { NavbarComponent } from './navbar/navbar.component';
 import { SharedModule } from './shared/shared.module';
+import { ReviewConfirmationPageComponent } from './admin/review-confirmation-page/review-confirmation-page.component';
 
 @NgModule({
   declarations: [
@@ -69,6 +70,7 @@ import { SharedModule } from './shared/shared.module';
     SubmissionConfirmationPageComponent,
     ConfirmationPageComponent,
     ApproversComponent,
+    ReviewConfirmationPageComponent,
   ],
   imports: [
     ReactiveFormsModule,


### PR DESCRIPTION
I re-implemented the errorStateMatcher and removed 'export' keyword in approver.component.ts and review-employee.component.ts.

-review-employee.component.ts: used confirmation-page.service.ts and directed to review-confirmation-page.component.ts
-review-confirmation-page.component.ts: confirmation page when admin submits review
-app.module.ts: imported the new component: review-confirmation-page.component.ts
-app.module-routing.ts: set up link to new component:  review-confirmation-page.component.ts
